### PR TITLE
GCC 4.8, Betty and man pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,27 @@
 # Allow SSH connection to the container
 
 FROM ubuntu:14.04
-MAINTAINER Guillaume Salva <guillaume@holbertonschool.com>
+LABEL maintainer="Guillaume Salva <guillaume@holbertonschool.com>"
 
-RUN apt-get update
-RUN apt-get -y upgrade
+COPY run.sh /tmp/run.sh
 
-RUN apt-get install -y curl wget git vim emacs
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl wget git vim emacs \
+        openssh-server \
+        build-essential software-properties-common gcc-4.8 \
+        man manpages-dev manpages-posix-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -ri 's/^#PasswordAuthentication/PasswordAuthentication/' /etc/ssh/sshd_config \
+    && sed -ri 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config \
+    && git clone https://github.com/holbertonschool/Betty.git /tmp/Betty \
+        && cd /tmp/Betty \
+        && ./install.sh \
+        && cd - \
+        && rm -rf /tmp/Betty \
+    && chmod u+x /tmp/run.sh
 
-# SSH
-RUN apt-get install -y openssh-server
-RUN mkdir /var/run/sshd
-
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-RUN sed -ri 's/^#PasswordAuthentication/PasswordAuthentication/' /etc/ssh/sshd_config
-RUN sed -ri 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
-RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-
-ADD run.sh /tmp/run.sh
-RUN chmod u+x /tmp/run.sh
-
-# start run!
-CMD ["./tmp/run.sh"]
+CMD ["/tmp/run.sh"]


### PR DESCRIPTION
## Description

### Context

- Optimize image (reduce the number of layers) in order to gain space but also "save layers" with the new Docker API Rate limit.
- Add new software based on feedback
  - GCC 4.8
  - Betty
  - Man pages

### Summary

|                       | Layers | Image size |
|-----------------------|--------|------------|
| Before this PR        | 15     | 510MB      |
| After optimization    | 5      | 409MB      |
| After GCC, Betty, man | 5      | 548MB      |